### PR TITLE
wall-clock: Always consider that 12-h formats are available

### DIFF
--- a/libgnome-desktop/gnome-wall-clock.c
+++ b/libgnome-desktop/gnome-wall-clock.c
@@ -45,6 +45,7 @@ struct _GnomeWallClockPrivate {
 
 	gboolean time_only;
 	gboolean ampm_available;
+	gboolean fallback_ampm;
 };
 
 enum {
@@ -91,8 +92,10 @@ gnome_wall_clock_init (GnomeWallClock *self)
 				  G_CALLBACK (on_schema_change), self);
 
 	ampm = nl_langinfo (AM_STR);
-	if (ampm != NULL && *ampm != '\0')
-		self->priv->ampm_available = TRUE;
+
+	/* We will fallback to AM/PM in EOS if no localized string is found */
+	self->priv->fallback_ampm = (ampm == NULL || *ampm == '\0');
+	self->priv->ampm_available = TRUE;
 
 	update_clock (self);
 }
@@ -244,6 +247,7 @@ update_clock (gpointer data)
 	GnomeWallClock   *self = data;
 	GDesktopClockFormat clock_format;
 	const char *format_string;
+	char *format_string_dup;
 	gboolean show_full_date;
 	gboolean show_weekday;
 	gboolean show_seconds;
@@ -288,6 +292,7 @@ update_clock (gpointer data)
 			   in 24-hour mode. */
 			format_string = show_seconds ? _("%R:%S") : _("%R");
 		}
+		format_string_dup = g_strdup (format_string);
 	} else {
 		if (show_full_date) {
 			/* Translators: This is a time format with full date used
@@ -305,10 +310,21 @@ update_clock (gpointer data)
 			format_string = show_seconds ? _("%l:%M:%S %p")
 				: _("%l:%M %p");
 		}
+
+		/* Now add the AM/PM depending on whether we are in fallback mode */
+		if (self->priv->fallback_ampm) {
+			GDateTime *now = g_date_time_new_now (self->priv->timezone);
+			format_string_dup = g_strdup_printf ("%s%s",
+							     format_string,
+							     g_date_time_get_hour (now) >= 12 ? "PM" : "AM");
+		} else {
+			format_string_dup = g_strdup (format_string);
+		}
 	}
 
 	g_free (self->priv->clock_string);
-	self->priv->clock_string = g_date_time_format (now, format_string);
+	self->priv->clock_string = g_date_time_format (now, format_string_dup);
+	g_free (format_string_dup);
 
 	g_date_time_unref (now);
 	g_date_time_unref (expiry);


### PR DESCRIPTION
Instead of checking whether the 12-h formats are available, consider
them always possible and simply fallback to a non-localized AM/PM string
if the current locale does not provice one.

[endlessm/eos-shell#4772]