### PR TITLE
gnome-bg: use language and not personality to determine default bg

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -145,8 +145,7 @@ AC_SUBST(XLIB_LIBS)
 
 dnl pkg-config dependency checks
 
-PKG_CHECK_MODULES(GNOME_DESKTOP, endless-0
-                                 gdk-pixbuf-2.0 >= $GDK_PIXBUF_REQUIRED
+PKG_CHECK_MODULES(GNOME_DESKTOP, gdk-pixbuf-2.0 >= $GDK_PIXBUF_REQUIRED
                                  gtk+-3.0 >= $GTK_REQUIRED
                                  glib-2.0 >= $GLIB_REQUIRED
                                  gio-2.0 >= $GLIB_REQUIRED


### PR DESCRIPTION
We now don't install backgrounds per-personality anymore. Just use a key
based on the language.

[endlessm/eos-shell#4831]