### PR TITLE
Install the libraries in the right multi-arch directory

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -16,6 +16,7 @@ override_dh_autoreconf:
 
 override_dh_auto_configure:
 	dh_auto_configure -- \
+		--libdir=\$${prefix}/lib/$(DEB_HOST_MULTIARCH) \
 		--libexecdir=\$${libdir}/$(LIB_PKG) \
 		--with-gnome-distributor=Endless \
 		--disable-date-in-gnome-version \


### PR DESCRIPTION
I overlooked this change when rebasing on top of 3.22, adding it now.

https://phabricator.endlessm.com/T16337