### PR TITLE
debian/control: Bump dependency on gsettings-desktop-schemas

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -29,7 +29,7 @@ Build-Depends: debhelper (>= 10),
                libudev-dev [linux-any],
                gobject-introspection (>= 0.10.2-1~),
                libgirepository1.0-dev (>= 0.10.2-1~),
-               gsettings-desktop-schemas-dev (>= 3.5.91),
+               gsettings-desktop-schemas-dev (>= 3.24.0-2endless1),
                yelp-tools
 
 Package: gnome-desktop3-data
@@ -47,7 +47,7 @@ Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${misc:Depends},
          ${shlibs:Depends},
-         gsettings-desktop-schemas (>= 3.5.91),
+         gsettings-desktop-schemas (>= 3.24.0-2endless1),
          gnome-desktop3-data (>= ${source:Version})
 Replaces: libgnome-desktop-3-2 (<< 3.5.2),
           libgnome-desktop-3-4 (<< 3.7.90)

--- a/debian/control.in
+++ b/debian/control.in
@@ -25,7 +25,7 @@ Build-Depends: debhelper (>= 10),
                libudev-dev [linux-any],
                gobject-introspection (>= 0.10.2-1~),
                libgirepository1.0-dev (>= 0.10.2-1~),
-               gsettings-desktop-schemas-dev (>= 3.5.91),
+               gsettings-desktop-schemas-dev (>= 3.24.0-2endless1),
                yelp-tools
 
 Package: gnome-desktop3-data
@@ -43,7 +43,7 @@ Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${misc:Depends},
          ${shlibs:Depends},
-         gsettings-desktop-schemas (>= 3.5.91),
+         gsettings-desktop-schemas (>= 3.24.0-2endless1),
          gnome-desktop3-data (>= ${source:Version})
 Replaces: libgnome-desktop-3-2 (<< 3.5.2),
           libgnome-desktop-3-4 (<< 3.7.90)


### PR DESCRIPTION
We need 3.24.0 now that we're relying on a patch to honour the
`clock-show-weekday` GSettings key, added on top of that version.

https://phabricator.endlessm.com/T18781