### PR TITLE
gnome-rr: extend builtin display check for nvidia driver

### DIFF
--- a/libgnome-desktop/gnome-rr.c
+++ b/libgnome-desktop/gnome-rr.c
@@ -1696,7 +1696,8 @@ gnome_rr_output_is_builtin_display (GnomeRROutput *output)
 {
     g_return_val_if_fail (output != NULL, FALSE);
 
-    return _gnome_rr_output_name_is_builtin_display (output->name);
+    return _gnome_rr_output_name_is_builtin_display (output->name) ||
+           g_strcmp0 (output->display_name, "Built-in display") == 0;
 }
 
 /**


### PR DESCRIPTION
The proprietary nvidia driver shows internal laptop panels connected
over DP (not eDP), so they are not detected as builtin.

However, we can use the display name to detect this case, which
clearly describes a built-in display.

https://phabricator.endlessm.com/T19517