### PR TITLE
Revert "gnome-rr: Add name property to the mode"

### DIFF
--- a/libgnome-desktop/gnome-rr.c
+++ b/libgnome-desktop/gnome-rr.c
@@ -110,7 +110,6 @@ struct GnomeRRMode
 {
     ScreenInfo *	info;
     guint		id;
-    char *		name;
     glong               winsys_id;
     int			width;
     int			height;
@@ -486,7 +485,7 @@ fill_screen_info_from_resources (ScreenInfo *info,
 	GnomeRRMode *mode;
 
 	g_variant_get_child (modes, i, META_MONITOR_MODE_STRUCT, &id,
-			     NULL, NULL, NULL, NULL, NULL, NULL);
+			     NULL, NULL, NULL, NULL, NULL);
 	mode = mode_new (info, id);
 
 	g_ptr_array_add (a, mode);
@@ -2031,13 +2030,6 @@ gnome_rr_mode_get_id (GnomeRRMode *mode)
     return mode->id;
 }
 
-const char *
-gnome_rr_mode_get_name (GnomeRRMode *mode)
-{
-    g_return_val_if_fail (mode != NULL, 0);
-    return mode->name;
-}
-
 guint
 gnome_rr_mode_get_width (GnomeRRMode *mode)
 {
@@ -2093,7 +2085,7 @@ mode_initialize (GnomeRRMode *mode, GVariant *info)
     gdouble frequency;
 
     g_variant_get (info, META_MONITOR_MODE_STRUCT,
-		   &mode->id, &mode->name, &mode->winsys_id,
+		   &mode->id, &mode->winsys_id,
 		   &mode->width, &mode->height,
 		   &frequency, &mode->flags);
     
@@ -2106,7 +2098,6 @@ mode_copy (const GnomeRRMode *from)
     GnomeRRMode *to = g_slice_new0 (GnomeRRMode);
 
     to->id = from->id;
-    to->name = g_strdup (from->name);
     to->info = from->info;
     to->width = from->width;
     to->height = from->height;
@@ -2118,7 +2109,6 @@ mode_copy (const GnomeRRMode *from)
 static void
 mode_free (GnomeRRMode *mode)
 {
-    g_free (mode->name);
     g_slice_free (GnomeRRMode, mode);
 }
 

--- a/libgnome-desktop/gnome-rr.h
+++ b/libgnome-desktop/gnome-rr.h
@@ -179,7 +179,6 @@ gboolean        gnome_rr_output_supports_underscanning (GnomeRROutput       *out
 
 /* GnomeRRMode */
 guint32         gnome_rr_mode_get_id               (GnomeRRMode           *mode);
-const char *    gnome_rr_mode_get_name             (GnomeRRMode           *mode);
 guint           gnome_rr_mode_get_width            (GnomeRRMode           *mode);
 guint           gnome_rr_mode_get_height           (GnomeRRMode           *mode);
 int             gnome_rr_mode_get_freq             (GnomeRRMode           *mode);

--- a/libgnome-desktop/meta-xrandr-shared.h
+++ b/libgnome-desktop/meta-xrandr-shared.h
@@ -37,5 +37,5 @@ typedef enum {
 
 #define META_OUTPUT_STRUCT         "(uxiausauau@a{sv})"
 #define META_CRTC_STRUCT           "(uxiiiiiuau@a{sv})"
-#define META_MONITOR_MODE_STRUCT   "(usxuudu)"
+#define META_MONITOR_MODE_STRUCT   "(uxuudu)"
 #endif

--- a/libgnome-desktop/xrandr.xml
+++ b/libgnome-desktop/xrandr.xml
@@ -112,7 +112,6 @@
 	Multiple outputs in the same CRTCs must all have the same mode.
 	A mode is exposed as:
 	* u ID: the ID in the API
-	* s name: the name, suitable for showing to the user
 	* x winsys_id: the low-level ID of this mode
 	* u width, height: the resolution
 	* d frequency: refresh rate
@@ -135,7 +134,7 @@
       <arg name="serial" direction="out" type="u" />
       <arg name="crtcs" direction="out" type="a(uxiiiiiuaua{sv})" />
       <arg name="outputs" direction="out" type="a(uxiausauaua{sv})" />
-      <arg name="modes" direction="out" type="a(usxuudu)" />
+      <arg name="modes" direction="out" type="a(uxuudu)" />
       <arg name="max_screen_width" direction="out" type="i" />
       <arg name="max_screen_height" direction="out" type="i" />
     </method>


### PR DESCRIPTION
This was only used by g-c-c, which is no longer using libgnome-desktop
to retrieve this information, but calling Mutter's GetCurrentState
method from the org.gnome.Mutter.Display config interface directly.

This reverts commit 2c4fc57c8a521f8b5c9d03b749055abc3d83d7b2, and
should be dropped along with the original commit for future rebases.

https://phabricator.endlessm.com/T20655