### PR TITLE
Drop gnome_rr_mode_get_name from the list of symbols.

### DIFF
--- a/debian/libgnome-desktop-3-12.symbols
+++ b/debian/libgnome-desktop-3-12.symbols
@@ -100,7 +100,6 @@ libgnome-desktop-3.so.12 libgnome-desktop-3-12 #MINVER#
  gnome_rr_mode_get_freq_f@Base 3.19.93
  gnome_rr_mode_get_height@Base 3.17.92
  gnome_rr_mode_get_id@Base 3.17.92
- gnome_rr_mode_get_name@Base 3.10.2+dev14.eb6f2e3-1bed1
  gnome_rr_mode_get_is_interlaced@Base 3.21.4
  gnome_rr_mode_get_is_tiled@Base 3.17.92
  gnome_rr_mode_get_type@Base 3.17.92


### PR DESCRIPTION
This API is no longer available since 3.26, and this patch
should be dropped in future rebases.

https://phabricator.endlessm.com/T20655